### PR TITLE
Rename as_number to asn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ mod test {
             timezone: "America/New_York".to_string(),
             isp: "Google LLC".to_string(),
             org: "Google Public DNS".to_string(),
-            as_number: "AS15169 Google LLC".to_string(),
+            asn: "AS15169 Google LLC".to_string(),
         };
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected);
@@ -173,7 +173,7 @@ mod test {
             timezone: "America/New_York".to_string(),
             isp: "Google LLC".to_string(),
             org: "Google Public DNS".to_string(),
-            as_number: "AS15169 Google LLC".to_string(),
+            asn: "AS15169 Google LLC".to_string(),
         };
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected);
@@ -222,7 +222,7 @@ mod test {
             timezone: "America/New_York".to_string(),
             isp: "Google LLC".to_string(),
             org: "Google Public DNS".to_string(),
-            as_number: "AS15169 Google LLC".to_string(),
+            asn: "AS15169 Google LLC".to_string(),
         };
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected);
@@ -247,7 +247,7 @@ mod test {
             timezone: "America/New_York".to_string(),
             isp: "Google LLC".to_string(),
             org: "Google Public DNS".to_string(),
-            as_number: "AS15169 Google LLC".to_string(),
+            asn: "AS15169 Google LLC".to_string(),
         };
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected);

--- a/src/model/ip_response.rs
+++ b/src/model/ip_response.rs
@@ -26,7 +26,7 @@ pub struct IpFullResponse {
     pub isp: String,
     pub org: String,
     #[serde(rename = "as")]
-    pub as_number: String,
+    pub asn: String,
     #[serde(rename = "asname")]
     pub as_name: String,
     pub reverse: String,
@@ -55,7 +55,7 @@ pub struct IpDefaultResponse {
     pub isp: String,
     pub org: String,
     #[serde(rename = "as")]
-    pub as_number: String,
+    pub asn: String,
 }
 
 /// A module that contains the error type for the library.


### PR DESCRIPTION
Reason:

It's very easy to think that as_number returns a number when it actually returns a string.
It's misleading.